### PR TITLE
2.0.1 via tar

### DIFF
--- a/com.revolutionarygamesstudio.ThriveLauncher.appdata.xml
+++ b/com.revolutionarygamesstudio.ThriveLauncher.appdata.xml
@@ -83,6 +83,28 @@
 	<launchable type="desktop-id">com.revolutionarygamesstudio.ThriveLauncher.desktop</launchable>
 
 	<releases>
+		<release version="2.0.1" date="2022-12-08">
+			<url>https://github.com/Revolutionary-Games/Thrive-Launcher/releases/tag/v2.0.1</url>
+			<description>
+				<p>Changes</p>
+				<ul>
+				<li>Added contextual explanations to some of the launcher options as to why they are disabled</li>
+				<li>Added a guard against invalid locale name breaking the launcher</li>
+				<li>Added a button to clear the remembered (last played) version</li>
+				<li>Background task errors are now properly handled and a warning popup is now shown to the user</li>
+				<li>Fixed "no compatible Thrive versions found" warning popping up when it shouldn't</li>
+				<li>Fixed Ukrainian locale being attempted to be loaded with the wrong name</li>
+				<li>Fixed the initial launcher running causing settings to immediately change due to default language</li>
+				<li>Fixed the reset all settings button not resetting the launcher language correctly</li>
+				<li>Fixed the playing popup title being unset if the launcher window was reopened after Thrive was ran</li>
+				<li>Print the message about waiting for child process to exit once per minute</li>
+				<li>Seamless mode option is now correctly only shown when the launcher is a store version</li>
+				<li>Did some code cleanup and removed TODOs that were already done</li>
+				<li>New languages: German, Romanian, Swedish, Russian</li>
+				<li>Updated translations</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.0.0" date="2022-12-03">
 			<url>https://github.com/Revolutionary-Games/Thrive-Launcher/releases/tag/v2.0.0</url>
 			<description>

--- a/com.revolutionarygamesstudio.ThriveLauncher.yaml
+++ b/com.revolutionarygamesstudio.ThriveLauncher.yaml
@@ -29,7 +29,7 @@ modules:
 
       - type: git
         url: https://github.com/Revolutionary-Games/Thrive-Launcher.git
-        commit: ed7ea34cf2a1ecfd4728d16976577636f63b522d
+        commit: 3295ea20f0f04ff20dbb2dda3e249aadf60e2783
 
       - type: archive
         dest: dotnet-sdk

--- a/com.revolutionarygamesstudio.ThriveLauncher.yaml
+++ b/com.revolutionarygamesstudio.ThriveLauncher.yaml
@@ -29,7 +29,7 @@ modules:
 
       - type: git
         url: https://github.com/Revolutionary-Games/Thrive-Launcher.git
-        commit: 3295ea20f0f04ff20dbb2dda3e249aadf60e2783
+        tag: "v2.0.1"
 
       - type: archive
         dest: dotnet-sdk

--- a/com.revolutionarygamesstudio.ThriveLauncher.yaml
+++ b/com.revolutionarygamesstudio.ThriveLauncher.yaml
@@ -26,10 +26,9 @@ modules:
         DOTNET_CLI_TELEMETRY_OPTOUT: "true"
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
     sources:
-
-      - type: git
-        url: https://github.com/Revolutionary-Games/Thrive-Launcher.git
-        tag: "v2.0.1"
+      - type: archive
+        url: https://cdn.shosetsu.app/thrive/Thrive-Launcher-v2.0.1.tar.xz
+        sha256: 80922ead59fb597339073396e02f432a423199541e8d808c7bf4e279ac2b288c
 
       - type: archive
         dest: dotnet-sdk

--- a/nuget_sources.json
+++ b/nuget_sources.json
@@ -407,10 +407,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/moq/4.18.2/moq.4.18.2.nupkg",
-        "sha512": "f7c8145e759399b13d5dd1b3acec8ebdfd898a4923e17a2a6cfa842d3a587d2b03f9bc3623ef952234e3db6efd602f3db7b05196bdf89a2ccaca7eecf487d4c2",
+        "url": "https://api.nuget.org/v3-flatcontainer/moq/4.18.3/moq.4.18.3.nupkg",
+        "sha512": "6cf733f5404f50824caf6b367b8ac756e307c237157bdda81e54eed4fdf79f812e8e01653f0cfb0ed3886d876fbf5486c94663b1bf556277bb1333b9c1426735",
         "dest": "nuget-sources",
-        "dest-filename": "moq.4.18.2.nupkg"
+        "dest-filename": "moq.4.18.3.nupkg"
     },
     {
         "type": "file",
@@ -1394,10 +1394,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/xamlnamereferencegenerator/1.4.2/xamlnamereferencegenerator.1.4.2.nupkg",
-        "sha512": "74344d1d2dfda9ed362e83c58ad02eb56b141176007d49aebfac774690cb3dc95a56e3bb567bfd1b0da3305f923346bc5116149a17387f0b0ebcc7cd6e7a6a0c",
+        "url": "https://api.nuget.org/v3-flatcontainer/xamlnamereferencegenerator/1.5.1/xamlnamereferencegenerator.1.5.1.nupkg",
+        "sha512": "39ea7a63641a21d272f966cd93a63fca173a165a302b382367cf6b36b5ad508c2f469e9abc90ea7e4af654c96644b750b8842f6bc896dc9ab1e2063805760771",
         "dest": "nuget-sources",
-        "dest-filename": "xamlnamereferencegenerator.1.4.2.nupkg"
+        "dest-filename": "xamlnamereferencegenerator.1.5.1.nupkg"
     },
     {
         "type": "file",


### PR DESCRIPTION
Instead of relying on experimental git lfs support, directly have the tars available for now.

The original v2.0.1 will remain open.